### PR TITLE
support configuring nats tools via the environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,8 +43,8 @@ func usage(exeType int) {
 }
 
 func main() {
-	var urls = flag.String("s", "connect.ngs.global", "The NATS System")
-	var userCreds = flag.String("creds", "", "User Credentials File")
+	var urls = flag.String("s", stringFromEnv("NATS_URL", "connect.ngs.global"), "The NATS System")
+	var userCreds = flag.String("creds", stringFromEnv("NATS_CREDS", ""), "User Credentials File")
 	var queue = flag.String("q", "NATS-RPLY-22", "Queue Group Name")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var showHelp = flag.Bool("h", false, "Show help message")
@@ -207,4 +207,13 @@ func toolName(exeType int) string {
 	default:
 		return "NATS-PUB TOOL"
 	}
+}
+
+func stringFromEnv(v string, d string) string {
+	val := os.Getenv(v)
+	if val == "" {
+		return d
+	}
+
+	return val
 }


### PR DESCRIPTION
We base the jsm container on the nats-box but this means for users
to test it they have to keep specifying -s and when they dont they
get weird auth errors that doesnt make sense

This will allow me to set an environment var in the jsm container
Dockerfile to a value that makes sense while keeping the current
behaviour of defaulting to ngs