### PR TITLE
non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,13 @@ RUN cd /usr/local/bin/ && \
     ln -s nats-box nats-req && \
     ln -s nats-box nats-rply
 
-WORKDIR /root
+WORKDIR /home/nats
+RUN addgroup -S -g 1002 natsgroup && adduser -S -u 1001 nats -G natsgroup
+USER nats
 
-USER root
-
-ENV NKEYS_PATH /nsc/nkeys
-ENV XDG_DATA_HOME /nsc
-ENV XDG_CONFIG_HOME /nsc/.config
+ENV NKEYS_PATH /home/nats/nsc/nkeys
+ENV XDG_DATA_HOME /home/nats/nats/nsc
+ENV XDG_CONFIG_HOME /home/nats/nsc/.config
 
 COPY .profile $WORKDIR
 


### PR DESCRIPTION
On some hardened kubenertes clusters, having containers with root access is prohibited (with Admission Controllers).
I propose here to use a non root user for nats-box.

This will allow to create the deployment in nats.io/k8s with a securityContext:

```
      securityContext:
        runAsUser: 1001
```

unfortunately, I don't know any method to use the user name instead of the user id.
That's why I'm fixing the user id, to something working in that image.