### PR TITLE
clean up  Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,11 @@ WORKDIR $GOPATH/src/github.com/nats-io/
 
 RUN apk add -U --no-cache git binutils
 
-RUN go install github.com/nats-io/nats-top@v0.4.0
+RUN go install github.com/nats-io/nats-top@latest
 
-RUN go install -ldflags "-X main.version=2.7.1" github.com/nats-io/nsc@2.7.1
+RUN go install github.com/nats-io/nsc@latest
 
-RUN mkdir -p src/github.com/nats-io && \
-    cd src/github.com/nats-io/ && \
-    git clone https://github.com/nats-io/natscli.git && \
-    cd natscli/nats && \
-    git fetch origin && \
-    git checkout v0.0.33 && \
-    go build -ldflags "-s -w -X main.version=0.0.33" -o /nats
+RUN go install github.com/nats-io/natscli/nats@latest
 
 RUN go install github.com/nats-io/stan.go/examples/stan-pub@latest
 RUN go install github.com/nats-io/stan.go/examples/stan-sub@latest
@@ -29,7 +23,6 @@ FROM alpine:3.14.6
 RUN apk add -U --no-cache ca-certificates figlet
 
 COPY --from=builder /go/bin/* /usr/local/bin/
-COPY --from=builder /nats /usr/local/bin/
 
 RUN cd /usr/local/bin/ && \
     ln -s nats-box nats-pub && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ WORKDIR $GOPATH/src/github.com/nats-io/
 
 RUN apk add -U --no-cache git binutils
 
-RUN go install github.com/nats-io/nats-top@latest
+RUN go install github.com/nats-io/nats-top@v0.5.2
 
-RUN go install github.com/nats-io/nsc@latest
+RUN go install -ldflags="-X main.version=2.7.1" github.com/nats-io/nsc@2.7.1
 
-RUN go install github.com/nats-io/natscli/nats@latest
+RUN go install github.com/nats-io/natscli/nats@v0.0.33
 
 RUN go install github.com/nats-io/stan.go/examples/stan-pub@latest
 RUN go install github.com/nats-io/stan.go/examples/stan-sub@latest


### PR DESCRIPTION
It is now possible to just use go install xxxx@latest for all the components, which IMHO makes the Dockerfile cleaner and doesn't have to be edited with specific version numbers each time there's an update of one of the components