### PR TITLE
Correct alias in .profile

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,6 +1,6 @@
 alias stan-sub="stan_sub"
 alias stan-pub="stan_pub"
-alias stan-pub="stan_bench"
+alias stan-bench="stan_bench"
 alias nats-top="nats_top"
 
 function stan_sub() {


### PR DESCRIPTION
Currently the alias in .profile aliases stan_pub to stan-bench. Noticed it and also saw that there was an issue created about it.
Resolves #26 