### PR TITLE
feat: update to alpine 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go install github.com/nats-io/stan.go/examples/stan-pub@latest
 RUN go install github.com/nats-io/stan.go/examples/stan-sub@latest
 RUN go install github.com/nats-io/stan.go/examples/stan-bench@latest
 
-FROM alpine:3.14.6
+FROM alpine:3.16.2
 
 RUN apk add -U --no-cache ca-certificates figlet jq
 


### PR DESCRIPTION
Updated nats-box image to use alpine 3.16 to fix the following issues that were found:

```
natsio/nats-box:0.13.1 (alpine 3.14.6)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 1)

┌──────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-2097  │ MEDIUM   │ 1.1.1n-r0         │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
├──────────────┤                │          │                   │               │                                                             │
│ libssl1.1    │                │          │                   │               │                                                             │
│              │                │          │                   │               │                                                             │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ zlib         │ CVE-2022-37434 │ CRITICAL │ 1.2.12-r0         │ 1.2.12-r2     │ zlib: heap-based buffer over-read and overflow in inflate() │
│              │                │          │                   │               │ in inflate.c via a...                                       │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-37434                  │
└──────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

```