### PR TITLE
bump various versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Setup Docker Hub
       uses: docker/login-action@v2

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,11 +16,11 @@ variable CI {
 }
 
 variable image_base {
-  default = "docker-image://alpine:3.17.1"
+  default = "docker-image://alpine:3.17.2"
 }
 
 variable image_golang {
-  default = "docker-image://golang:1.19.5-alpine"
+  default = "docker-image://golang:1.19.7-alpine"
 }
 
 ###################
@@ -65,7 +65,7 @@ target "nats-box" {
   args = {
     VERSION_NATS        = "0.0.35"
     VERSION_NATS_TOP    = "0.5.3"
-    VERSION_NSC         = "2.7.8"
+    VERSION_NSC         = "2.8.0"
     VERSION_STAN        = "0.10.4"
   }
   platforms  = get_platforms_multiarch()


### PR DESCRIPTION
* GitHub Action docker/setup-buildx-action to v2s
  + to avoid the Node.js 12 deprecation by GitHub and should get rid of state/output warnings from GHA
* Alpine Linux to 3.17.2 (patch-level bump)
* Golang to 1.19.7 (various security fixes)
