### PR TITLE
run as non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG VERSION_STAN
 
 ENV GOPATH /go/${TARGETARCH}
 
-RUN <<EOT 
+RUN <<EOT
     set -e
     mkdir -p ${GOPATH}
 
@@ -37,9 +37,9 @@ RUN <<EOT
     adduser -D -u 1000 -G nats nats
 EOT
 
-ENV NKEYS_PATH /nsc/nkeys
-ENV XDG_DATA_HOME /nsc
-ENV XDG_CONFIG_HOME /nsc/.config
+ENV NKEYS_PATH /home/nats/nsc/nkeys
+ENV XDG_DATA_HOME /home/nats/nsc
+ENV XDG_CONFIG_HOME /home/nats/nsc/.config
 
 COPY entrypoint.sh /entrypoint.sh
 
@@ -47,6 +47,8 @@ COPY profile.sh /etc/profile.d
 
 RUN chmod +x /entrypoint.sh
 
-WORKDIR /root
+WORKDIR /home/nats
+
+USER nats
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-if [[ "${HOME}" != "/root" && "${PWD}" == "/root" ]]; then
-  cd "${HOME}"
-fi
-
 if [[ $# -ne 0 ]]; then
   exec "$@"
 else


### PR DESCRIPTION
as per title

we have issues running this container on openshift due to security constraints so forcing the container to run as 'nats' user that for some reason was already created but not used

struggled to build the image as is so tested with the following

Test Dockerfile
```
FROM harbor.tools.telstra.com/public-cache/natsio/nats-box:0.14.1

ENV NKEYS_PATH /home/nats/nsc/nkeys
ENV XDG_DATA_HOME /home/nats/nsc
ENV XDG_CONFIG_HOME /home/nats/nsc/.config

WORKDIR /home/nats

USER nats

```

Results
```
             _             _               
 _ __   __ _| |_ ___      | |__   _____  __
| '_ \ / _` | __/ __|_____| '_ \ / _ \ \/ /
| | | | (_| | |_\__ \_____| |_) | (_) >  < 
|_| |_|\__,_|\__|___/     |_.__/ \___/_/\_\
                                           
nats-box v0.14.1
a9137ff55d4a:~$ whoami
nats
a9137ff55d4a:~$ ps -ef
PID   USER     TIME  COMMAND
    1 nats      0:00 /bin/sh -l
    9 nats      0:00 ps -ef
a9137ff55d4a:~$ nsc
nsc creates NATS operators, accounts, users, and manage their permissions.

Usage:
  nsc [flags]
  nsc [command]

Available Commands:
  add         Add assets such as accounts, imports, users
  completion  Generate the autocompletion script for the specified shell
  delete      Delete imports and exports
  describe    Describe assets such as operators, accounts, users, and jwt files
  edit        Edit assets such as accounts, imports, and users
  env         Prints and manage the nsc environment
  export      Export assets such as nkeys
  generate    Generate activations, creds, configs or nkeys
  help        Help about any command
  import      Import assets such as nkeys
  init        Initialize an environment by creating an operator, account and user
  keys        Manage keys for operators, accounts, and users
  list        List assets such as accounts, imports, users
  load        install entities for an operator, account and key
  pull        Pull an operator or account jwt replacing the local jwt with the server's version
  push        Push an account jwt to an Account JWT Server
  reissue     Re-issue objects with a new identity key
  revocations Manage revocation for users and activations from an account
  select      Set the current operator or account
  tool        NATS tools: pub, sub, req, rep, rtt
  update      Update this tool to latest version
  validate    Validate an operator, account(s), and users

Flags:
  -H, --all-dirs string       sets --config-dir, --data-dir, and --keystore-dir to the same value
      --config-dir string     nsc config directory
      --data-dir string       nsc data store directory
  -h, --help                  help for nsc
  -i, --interactive           ask questions for various settings
      --keystore-dir string   nsc keystore directory
  -K, --private-key string    Key used to sign. Can be specified as role (where applicable),
                              public key (private portion is retrieved)
                              or file path to a private key or private key 
  -v, --version               version for nsc

Use "nsc [command] --help" for more information about a command.
a9137ff55d4a:~$ ls -la
total 20
drwxr-sr-x    1 nats     nats          4096 Oct 25 12:17 .
drwxr-xr-x    1 root     root          4096 Oct 11 21:08 ..
-rw-------    1 nats     nats            25 Oct 25 12:18 .ash_history
drwx--S---    4 nats     nats          4096 Oct 25 12:17 nsc
a9137ff55d4a:~$ find .
.
./nsc
./nsc/.config
./nsc/.config/nats
./nsc/.config/nats/nsc
./nsc/.config/nats/nsc/nsc.json
./nsc/nats
./nsc/nats/nsc
./nsc/nats/nsc/stores
./.ash_history
a9137ff55d4a:~$ 
```