### PR TITLE
Nonroot Working Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN <<EOT
     adduser -D -u 1000 -G nats nats
 
     mkdir -p /nsc
-    chown nats:root /nsc
-    chmod 0775 /nsc
+    chown nats:root /nsc /home/nats
+    chmod 0775 /nsc /home/nats
 EOT
 
 ENV NKEYS_PATH /nsc/nkeys

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -78,6 +78,7 @@ target "nats-box-nonroot" {
 FROM nats-box
 ARG USER
 USER $USER:$USER
+WORKDIR /home/nats
 EOT
 
   tags = get_tags_suffix("nats-box", "nonroot")


### PR DESCRIPTION
- Makes `/home/nats` group writable for root group
- Defaults `nonroot` image to `/home/nats` to reliably provide a usable working directory