### PR TITLE
update nsc, natscli and golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile-upstream:1.6
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.22.1-alpine AS builder
 
 LABEL maintainer "Derek Collison <derek@nats.io>"
 LABEL maintainer "Waldemar Quevedo <wally@nats.io>"
@@ -21,7 +21,7 @@ RUN <<EOT
     go install github.com/nats-io/natscli/nats@v${VERSION_NATS}
 EOT
 
-FROM alpine:3.19.0
+FROM alpine:3.19.1
 
 ARG TARGETARCH
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -57,9 +57,9 @@ group "default" {
 target "nats-box" {
   dockerfile = "Dockerfile"
   args = {
-    VERSION_NATS        = "0.1.1"
+    VERSION_NATS        = "0.1.4"
     VERSION_NATS_TOP    = "0.6.1"
-    VERSION_NSC         = "2.8.5"
+    VERSION_NSC         = "2.8.6"
   }
   platforms  = get_platforms_multiarch()
   tags       = get_tags("nats-box")


### PR DESCRIPTION
Go: 1.22.1
Alpine: 3.19.1

```
    VERSION_NATS        = "0.1.4"
    VERSION_NATS_TOP    = "0.6.1"
    VERSION_NSC         = "2.8.6"
```