### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Adjust build version
       id: embed_version
@@ -18,14 +18,14 @@ jobs:
         sed -i 's/^.*MARKER-REPLACE-LINE-IN-CI.*/echo "nats-box ${{ github.ref_name }}" >\&2/' profile.sh
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Setup Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_CLI_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
         echo tags="latest,${version}" >> $GITHUB_OUTPUT
 
     - name: Build and Push
-      uses: docker/bake-action@v2
+      uses: docker/bake-action@v5
       env:
         TAGS: "${{ steps.tags.outputs.tags }}"
         REGISTRY: "natsio"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#syntax=docker/dockerfile-upstream:1.6
-FROM golang:1.23.2-alpine AS builder
+#syntax=docker/dockerfile-upstream:1.12
+FROM golang:1.23.4-alpine AS builder
 
 LABEL maintainer "Derek Collison <derek@nats.io>"
 LABEL maintainer "Waldemar Quevedo <wally@nats.io>"
@@ -21,7 +21,7 @@ RUN <<EOT
     go install github.com/nats-io/natscli/nats@v${VERSION_NATS}
 EOT
 
-FROM alpine:3.20.3
+FROM alpine:3.21.0
 
 ARG TARGETARCH
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -57,9 +57,9 @@ group "default" {
 target "nats-box" {
   dockerfile = "Dockerfile"
   args = {
-    VERSION_NATS        = "0.1.5"
-    VERSION_NATS_TOP    = "0.6.2"
-    VERSION_NSC         = "2.10.0"
+    VERSION_NATS        = "0.1.6"
+    VERSION_NATS_TOP    = "0.6.3"
+    VERSION_NSC         = "2.10.2"
   }
   platforms  = get_platforms_multiarch()
   tags       = get_tags("nats-box")


### PR DESCRIPTION
- Update NATS CLI to `0.1.6`
- Update NATS Top to `0.6.3`
- Update NSC to `2.10.2`
- Update Github actions