### PR TITLE
Update image versions and tool deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile-upstream:1.12
-FROM golang:1.23.7-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 LABEL maintainer "Derek Collison <derek@nats.io>"
 LABEL maintainer "Waldemar Quevedo <wally@nats.io>"
@@ -21,7 +21,7 @@ RUN <<EOT
     go install github.com/nats-io/natscli/nats@v${VERSION_NATS}
 EOT
 
-FROM alpine:3.21.3
+FROM alpine:3.22
 
 ARG TARGETARCH
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -57,9 +57,9 @@ group "default" {
 target "nats-box" {
   dockerfile = "Dockerfile"
   args = {
-    VERSION_NATS        = "0.2.0"
+    VERSION_NATS        = "0.2.3"
     VERSION_NATS_TOP    = "0.6.3"
-    VERSION_NSC         = "2.10.2"
+    VERSION_NSC         = "2.11.0"
   }
   platforms  = get_platforms_multiarch()
   tags       = get_tags("nats-box")


### PR DESCRIPTION
The image versions match what is used with the nats-server, specifically using Go 1.24 for builds and the recent Alpine 3.22 release.