### PR TITLE
fix(nats-box-non-root): Use numeric user ID for non-root nats user

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -71,8 +71,9 @@ target "nats-box-nonroot" {
     nats-box = "target:nats-box"
   }
   inherits = ["nats-box"]
+  # Use the numeric user ID for non-root nats user
   args = {
-    USER = "nats"
+    USER = "1000"
   }
   dockerfile-inline = <<EOT
 FROM nats-box


### PR DESCRIPTION
Fixes issue #87 by providing a numeric user, allowing Kubernetes to confirm that the container is running as a non-root user.