### PR TITLE
do not group PRs from renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,8 +37,7 @@
   packageRules: [
     {
       matchManagers: ['custom.regex'],
-      matchFileNames: ['docker-bake.hcl'],
-      groupName: 'NATS tools'
+      matchFileNames: ['docker-bake.hcl']
     }
   ]
 }


### PR DESCRIPTION
We want separate PRs, were PR title would list the version that was bumpted, not this:
https://github.com/nats-io/nats-box/pull/95